### PR TITLE
Add an ability to send nested structures to loggly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,23 +19,32 @@ default = ["runtime"]
 runtime = ["tokio"]
 
 [dependencies]
-bytes       = "0.4"
-chrono      = "0.4"
-futures     = "0.1"
-hyper       = "0.12"
-hyper-tls   = "0.3"
-serde       = "1.0"
-serde_json  = "1.0"
-slog        = "2.3"
-tokio-timer = "0.2.6"
+bytes        = "0.4"
+chrono       = "0.4"
+erased-serde = "0.3"
+futures      = "0.1"
+hyper        = "0.12"
+hyper-tls    = "0.3"
+serde        = "1.0"
+serde_json   = "1.0"
+tokio-timer  = "0.2.6"
 
 [dependencies.tokio]
 version  = "0.1"
 optional = true
 
+[dependencies.slog]
+version = "2.3"
+features = ["nested-values"]
+
 [dev-dependencies]
 tokio = "0.1"
+slog_derive = "0.1"
+serde = {version = "1.0", features = ["derive"]}
 
 [[example]]
 name = "log"
 required-features = ["runtime"]
+
+[[example]]
+name = "nested"

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,0 +1,37 @@
+use futures::Future;
+
+use serde::Serialize;
+use slog::{Drain, Logger};
+use slog_derive::SerdeValue;
+use slog_loggly::LogglyDrain;
+
+#[derive(Clone, Serialize, SerdeValue)]
+struct Item {
+    first: u32,
+    second: String,
+}
+
+fn main() {
+    // Your Loggly token and tag.
+    let loggly_token = "your-loggly-token";
+    let loggly_tag = "some-app";
+
+    // Create a custom Loggly drain.
+    let (drain, mut fhandle) = LogglyDrain::builder(loggly_token, loggly_tag)
+        .debug_mode(true)
+        .spawn_thread()
+        .unwrap();
+
+    // Create a logger.
+    let logger = Logger::root(drain.fuse(), slog::o!());
+
+    let item = Item {
+        first: 1,
+        second: "2".to_string(),
+    };
+
+    slog::debug!(logger, "debug"; "item" => item);
+
+    // flush all log messages
+    fhandle.flush().wait().unwrap();
+}

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -212,6 +212,10 @@ impl slog::Serializer for LogglyMessageSerializer {
             res
         })
     }
+
+    fn emit_serde(&mut self, key: Key, value: &slog::SerdeValue) -> slog::Result {
+        self.emit_serde_json_value(key, serde_json::json!(value.as_serde()))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This patch allows json serializable structs to be send to loggly as nested records.
Loggly web gui can perform queries inside the nested records e.g. `tag:"recording-streamer" json.dynamo_item.items.discontinuity:"false"`.

And you have a better view of the record inside loggly. 

![loggly-nested](https://user-images.githubusercontent.com/2659336/63358705-c9702e00-c36b-11e9-872f-2c79de95f61b.png)
